### PR TITLE
Added ability to configure Browsershot driver instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ Currently two drivers are supported:
 
 ### Browsershot Driver
 
-This is the  driver and requires [spatie/browsershot](https://github.com/spatie/browsershot). Please follow the installation instructions for that package.
+This is the default driver and requires [spatie/browsershot](https://github.com/spatie/browsershot). Please follow the installation instructions for that package.
+
+You can configure the Browsershot driver via `BrowsershotDriver::configureUsing()` in your `AppServiceProvider`:
+
+```php
+BrowsershotDriver::configureUsing(
+    fn (Browsershot $browser) => $browser->setCustomTempPath(storage_path('tmp'));
+});
+```
 
 ### Wkhtmltopdf Driver
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ You can configure the Browsershot driver via `BrowsershotDriver::configureUsing(
 
 ```php
 BrowsershotDriver::configureUsing(
-    fn (Browsershot $browser) => $browser->setCustomTempPath(storage_path('tmp'));
-});
+    fn (Browsershot $browser) => $browser->setCustomTempPath(storage_path('tmp'))
+);
 ```
 
 ### Wkhtmltopdf Driver

--- a/config/pdfable.php
+++ b/config/pdfable.php
@@ -13,36 +13,6 @@ return [
         'wkhtmltopdf' => WkhtmltopdfAdapter::class,
     ],
 
-    // Configure browsershot driver
-    'browsershot' => [
-        // Customize path to Google Chrome's binary
-        'chrome_path' => null,
-
-        // Set optional arguments for chrome. All of these arguments
-        // will automatically be prefixed with --
-        'chromium_arguments' => [],
-
-        // Define other puppeteer options
-        'options' => [
-            'headless' => 'new',
-        ],
-
-        // Set path to node binary if it is not in $PATH
-        'node_binary' => null,
-
-        // Set path to NPM binary if it is not in $PATH
-        'npm_binary' => null,
-
-        // If you want to use an alternative node_modules source you can
-        // set it here by specifying path to your node_modules directory.
-        'node_modules_path' => null,
-
-        // If you don't want to manually specify binary paths,
-        // but rather modify the include path in general, you can
-        // set it here e.g. 'include_path' => '$PATH:/usr/local/bin'
-        'include_path' => null,
-    ],
-
     'layout' => [
         'defaults' => [
             'page-size' => PageSize::A4,

--- a/config/pdfable.php
+++ b/config/pdfable.php
@@ -13,6 +13,36 @@ return [
         'wkhtmltopdf' => WkhtmltopdfAdapter::class,
     ],
 
+    // Configure browsershot driver
+    'browsershot' => [
+        // Customize path to Google Chrome's binary
+        'chrome_path' => null,
+
+        // Set optional arguments for chrome. All of these arguments
+        // will automatically be prefixed with --
+        'chromium_arguments' => [],
+
+        // Define other puppeteer options
+        'options' => [
+            'headless' => 'new',
+        ],
+
+        // Set path to node binary if it is not in $PATH
+        'node_binary' => null,
+
+        // Set path to NPM binary if it is not in $PATH
+        'npm_binary' => null,
+
+        // If you want to use an alternative node_modules source you can
+        // set it here by specifying path to your node_modules directory.
+        'node_modules_path' => null,
+
+        // If you don't want to manually specify binary paths,
+        // but rather modify the include path in general, you can
+        // set it here e.g. 'include_path' => '$PATH:/usr/local/bin'
+        'include_path' => null,
+    ],
+
     'layout' => [
         'defaults' => [
             'page-size' => PageSize::A4,

--- a/src/Drivers/BrowsershotDriver.php
+++ b/src/Drivers/BrowsershotDriver.php
@@ -12,11 +12,56 @@ class BrowsershotDriver implements Driver
         $html = $pdf->getView()->render();
         $page = $pdf->page();
 
+        $browser = Browsershot::html($html)
+            ->paperSize($page->getWidth(), $page->getHeight())
+            ->margins(...$page->getMargins());
+
+        // Configure browsershot
+        if (filled(config('pdfable.browsershot.chrome_path'))) {
+            $browser->setChromePath(
+                config('pdfable.browsershot.chrome_path')
+            );
+        }
+
+        if (filled(config('pdfable.browsershot.chromium_arguments'))) {
+            $browser->addChromiumArguments(
+                config('pdfable.browsershot.chromium_arguments')
+            );
+        }
+
+        if (filled(config('pdfable.browsershot.node_binary'))) {
+            $browser->setNodeBinary(
+                config('pdfable.browsershot.node_binary')
+            );
+        }
+
+        if (filled(config('pdfable.browsershot.npm_binary'))) {
+            $browser->setNpmBinary(
+                config('pdfable.browsershot.npm_binary')
+            );
+        }
+
+        if (filled(config('pdfable.browsershot.include_path'))) {
+            $browser->setIncludePath(
+                config('pdfable.browsershot.include_path')
+            );
+        }
+
+        if (filled(config('pdfable.browsershot.node_modules_path'))) {
+            $browser->setNodeModulePath(
+                config('pdfable.browsershot.node_modules_path')
+            );
+        }
+
+        if (filled(config('pdfable.browsershot.options'))) {
+            collect(config('pdfable.browsershot.options'))
+                ->each(
+                    fn ($item, $key) => $browser->setOption($key, $item)
+                );
+        }
+
         return base64_decode(
-            Browsershot::html($html)
-                ->paperSize($page->getWidth(), $page->getHeight())
-                ->margins(...$page->getMargins())
-                ->base64pdf()
+            $browser->base64pdf()
         );
     }
 }

--- a/src/Drivers/BrowsershotDriver.php
+++ b/src/Drivers/BrowsershotDriver.php
@@ -24,7 +24,7 @@ class BrowsershotDriver implements Driver
 
         // Configure browsershot instance
         if (isset(self::$configurator)) {
-            $browser = call_user_func(self::$configurator, $browser);
+            $browser = call_user_func(static::$configurator, $browser);
         }
 
         return base64_decode(

--- a/src/Drivers/BrowsershotDriver.php
+++ b/src/Drivers/BrowsershotDriver.php
@@ -2,15 +2,16 @@
 
 namespace pxlrbt\LaravelPdfable\Drivers;
 
+use Closure;
 use pxlrbt\LaravelPdfable\Pdfable;
 use Spatie\Browsershot\Browsershot;
 
 class BrowsershotDriver implements Driver
 {
-    protected static $configurator = null;
+    protected static ?Closure $configureUsing = null;
 
-    public static function configureBrowsershot(callable $configurator): void {
-        static::$configurator = $configurator;
+    public static function configureUsing(Closure $callback): void {
+        static::$configureUsing = $callback;
     }
 
     public function getData(Pdfable $pdf): ?string
@@ -21,10 +22,9 @@ class BrowsershotDriver implements Driver
         $browser = Browsershot::html($html)
             ->paperSize($page->getWidth(), $page->getHeight())
             ->margins(...$page->getMargins());
-
-        // Configure browsershot instance
-        if (isset(self::$configurator)) {
-            $browser = call_user_func(static::$configurator, $browser);
+        
+        if (self::$configureUsing !== null) {
+            $browser = call_user_func(static::$configureUsing, $browser);
         }
 
         return base64_decode(

--- a/src/Drivers/BrowsershotDriver.php
+++ b/src/Drivers/BrowsershotDriver.php
@@ -7,6 +7,12 @@ use Spatie\Browsershot\Browsershot;
 
 class BrowsershotDriver implements Driver
 {
+    protected static $configurator = null;
+
+    public static function configureBrowsershot(callable $configurator): void {
+        static::$configurator = $configurator;
+    }
+
     public function getData(Pdfable $pdf): ?string
     {
         $html = $pdf->getView()->render();
@@ -17,56 +23,12 @@ class BrowsershotDriver implements Driver
             ->margins(...$page->getMargins());
 
         // Configure browsershot instance
-        $this->configureBrowsershot($browser);
+        if (isset(self::$configurator)) {
+            $browser = call_user_func(self::$configurator, $browser);
+        }
 
         return base64_decode(
             $browser->base64pdf()
         );
-    }
-
-    protected function configureBrowsershot(Browsershot $browserShot)
-    {
-        if (filled(config('pdfable.browsershot.chrome_path'))) {
-            $browserShot->setChromePath(
-                config('pdfable.browsershot.chrome_path')
-            );
-        }
-
-        if (filled(config('pdfable.browsershot.chromium_arguments'))) {
-            $browserShot->addChromiumArguments(
-                config('pdfable.browsershot.chromium_arguments')
-            );
-        }
-
-        if (filled(config('pdfable.browsershot.node_binary'))) {
-            $browserShot->setNodeBinary(
-                config('pdfable.browsershot.node_binary')
-            );
-        }
-
-        if (filled(config('pdfable.browsershot.npm_binary'))) {
-            $browserShot->setNpmBinary(
-                config('pdfable.browsershot.npm_binary')
-            );
-        }
-
-        if (filled(config('pdfable.browsershot.include_path'))) {
-            $browserShot->setIncludePath(
-                config('pdfable.browsershot.include_path')
-            );
-        }
-
-        if (filled(config('pdfable.browsershot.node_modules_path'))) {
-            $browserShot->setNodeModulePath(
-                config('pdfable.browsershot.node_modules_path')
-            );
-        }
-
-        if (filled(config('pdfable.browsershot.options'))) {
-            collect(config('pdfable.browsershot.options'))
-                ->each(
-                    fn ($item, $key) => $browserShot->setOption($key, $item)
-                );
-        }
     }
 }

--- a/src/Drivers/BrowsershotDriver.php
+++ b/src/Drivers/BrowsershotDriver.php
@@ -16,39 +16,48 @@ class BrowsershotDriver implements Driver
             ->paperSize($page->getWidth(), $page->getHeight())
             ->margins(...$page->getMargins());
 
-        // Configure browsershot
+        // Configure browsershot instance
+        $this->configureBrowsershot($browser);
+
+        return base64_decode(
+            $browser->base64pdf()
+        );
+    }
+
+    protected function configureBrowsershot(Browsershot $browserShot)
+    {
         if (filled(config('pdfable.browsershot.chrome_path'))) {
-            $browser->setChromePath(
+            $browserShot->setChromePath(
                 config('pdfable.browsershot.chrome_path')
             );
         }
 
         if (filled(config('pdfable.browsershot.chromium_arguments'))) {
-            $browser->addChromiumArguments(
+            $browserShot->addChromiumArguments(
                 config('pdfable.browsershot.chromium_arguments')
             );
         }
 
         if (filled(config('pdfable.browsershot.node_binary'))) {
-            $browser->setNodeBinary(
+            $browserShot->setNodeBinary(
                 config('pdfable.browsershot.node_binary')
             );
         }
 
         if (filled(config('pdfable.browsershot.npm_binary'))) {
-            $browser->setNpmBinary(
+            $browserShot->setNpmBinary(
                 config('pdfable.browsershot.npm_binary')
             );
         }
 
         if (filled(config('pdfable.browsershot.include_path'))) {
-            $browser->setIncludePath(
+            $browserShot->setIncludePath(
                 config('pdfable.browsershot.include_path')
             );
         }
 
         if (filled(config('pdfable.browsershot.node_modules_path'))) {
-            $browser->setNodeModulePath(
+            $browserShot->setNodeModulePath(
                 config('pdfable.browsershot.node_modules_path')
             );
         }
@@ -56,12 +65,8 @@ class BrowsershotDriver implements Driver
         if (filled(config('pdfable.browsershot.options'))) {
             collect(config('pdfable.browsershot.options'))
                 ->each(
-                    fn ($item, $key) => $browser->setOption($key, $item)
+                    fn ($item, $key) => $browserShot->setOption($key, $item)
                 );
         }
-
-        return base64_decode(
-            $browser->base64pdf()
-        );
     }
 }


### PR DESCRIPTION
I really like your package, but I am currently not able to use it in scenario where my application is running inside Docker container. Underlying package spatie/browsershot is pretty configurable but I am not able to configure it when using your package.
That is why I made this pull request. Basically all I did is put bunch configuration options in the package config file and implemented those config options on Browsershot instance when generating PDF.

If you run chrome browser inside docker container you need add additional configuration flags to chrome binary in order to everything works, for example:

```php
Browsershot::html($html)
    ->setChromePath('/usr/bin/google-chrome')
    ->addChromiumArguments([
        'disable-gpu',
        'disable-dev-shm-usage',
        'disable-setuid-sandbox',
        'no-sandbox'
    ])
```

With this change in pull request these options can be set in pdfable.php config file, like this:

```php
[
    ...
    'browsershot' => [
        'chromium_arguments' => [
            'disable-gpu',
            'disable-dev-shm-usage',
            'disable-setuid-sandbox',
            'no-sandbox'
        ],

        'options' => [
            // This will use new headless mode which is prefered option
            'headless' => 'new'
        ]
    ],
]
```

You can also configure other parameters like binary to node or npm or setting or other puppeteer options.