### PR TITLE
Add Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0"
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
## Summary
- Widen `illuminate/contracts` constraint to include `^12.0`

## Test plan
- [x] Verified no breaking API changes in illuminate/contracts for v12