### PR TITLE
Add comprehensive Pest test suite

### DIFF
--- a/config/pdfable.php
+++ b/config/pdfable.php
@@ -1,7 +1,7 @@
 <?php
 
 use pxlrbt\LaravelPdfable\Drivers\BrowsershotDriver;
-use pxlrbt\LaravelPdfable\Drivers\WkhtmltopdfAdapter;
+use pxlrbt\LaravelPdfable\Drivers\WkhtmltopdfDriver;
 use pxlrbt\LaravelPdfable\Layout\PageOrientation;
 use pxlrbt\LaravelPdfable\Layout\PageSize;
 
@@ -10,7 +10,7 @@ return [
 
     'drivers' => [
         'browsershot' => BrowsershotDriver::class,
-        'wkhtmltopdf' => WkhtmltopdfAdapter::class,
+        'wkhtmltopdf' => WkhtmltopdfDriver::class,
     ],
 
     'layout' => [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,9 +6,12 @@ parameters:
     paths:
         - src
         - config
-        - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
+    ignoreErrors:
+        - message: '#Call to static method html\(\) on an unknown class Spatie\\Browsershot\\Browsershot#'
+          path: src/Drivers/BrowsershotDriver.php
+        - identifier: larastan.noEnvCallsOutsideOfConfig
+          path: config/pdfable.php
 

--- a/src/Concerns/CanAccessPropertiesAndMethods.php
+++ b/src/Concerns/CanAccessPropertiesAndMethods.php
@@ -17,7 +17,7 @@ trait CanAccessPropertiesAndMethods
     /**
      * The component attributes.
      *
-     * @var ComponentAttributeBag
+     * @var ?ComponentAttributeBag
      */
     public $attributes;
 
@@ -44,7 +44,7 @@ trait CanAccessPropertiesAndMethods
 
     public function data()
     {
-        $this->attributes = $this->attributes ?: $this->newAttributeBag();
+        $this->attributes = $this->attributes ?? $this->newAttributeBag();
 
         return array_merge($this->extractPublicProperties(), $this->extractPublicMethods());
     }

--- a/src/Concerns/CanAccessPropertiesAndMethods.php
+++ b/src/Concerns/CanAccessPropertiesAndMethods.php
@@ -17,7 +17,7 @@ trait CanAccessPropertiesAndMethods
     /**
      * The component attributes.
      *
-     * @var \Illuminate\View\ComponentAttributeBag
+     * @var ComponentAttributeBag
      */
     public $attributes;
 
@@ -122,7 +122,7 @@ trait CanAccessPropertiesAndMethods
     /**
      * Create an invokable, toStringable variable for the given component method.
      *
-     * @return \Illuminate\View\InvokableComponentVariable
+     * @return InvokableComponentVariable
      */
     protected function createInvokableVariable(string $method)
     {
@@ -164,7 +164,7 @@ trait CanAccessPropertiesAndMethods
     /**
      * Get a new attribute bag instance.
      *
-     * @return \Illuminate\View\ComponentAttributeBag
+     * @return ComponentAttributeBag
      */
     protected function newAttributeBag(array $attributes = [])
     {

--- a/src/Concerns/CanBeAttached.php
+++ b/src/Concerns/CanBeAttached.php
@@ -13,7 +13,7 @@ trait CanBeAttached
     {
         return Attachment::fromData(
             fn () => $this->driver()->getData($this),
-            $this->displayFilename() ?? 'attachment.pdf'
+            $this->displayFilename()
         );
     }
 }

--- a/src/Concerns/CanBeRendered.php
+++ b/src/Concerns/CanBeRendered.php
@@ -2,6 +2,8 @@
 
 namespace pxlrbt\LaravelPdfable\Concerns;
 
+use Illuminate\Contracts\View\View;
+
 trait CanBeRendered
 {
     public function displayFilename(): string
@@ -37,7 +39,7 @@ trait CanBeRendered
     /**
      * Entrypoint for responses
      */
-    public function render()
+    public function render(): string|View
     {
         $this->preview = true;
 

--- a/src/Layout/Page.php
+++ b/src/Layout/Page.php
@@ -10,9 +10,9 @@ class Page
 
     protected PageOrientation $orientation;
 
-    public static function make()
+    public static function make(): self
     {
-        return (new static)
+        return (new self)
             ->size(config('pdfable.layout.defaults.page-size'))
             ->orientation(config('pdfable.layout.defaults.orientation'))
             ->margins(config('pdfable.layout.defaults.margins'));

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,0 +1,27 @@
+<?php
+
+arch('source classes use strict types or valid PHP')
+    ->expect('pxlrbt\LaravelPdfable')
+    ->toBeClasses()
+    ->ignoring([
+        'pxlrbt\LaravelPdfable\Concerns',
+        'pxlrbt\LaravelPdfable\Layout\PageSize',
+        'pxlrbt\LaravelPdfable\Layout\PageOrientation',
+        'pxlrbt\LaravelPdfable\Drivers\Driver',
+    ]);
+
+arch('concerns are traits')
+    ->expect('pxlrbt\LaravelPdfable\Concerns')
+    ->toBeTraits();
+
+arch('enums are enums')
+    ->expect('pxlrbt\LaravelPdfable\Layout\PageSize')
+    ->toBeEnum();
+
+arch('driver interface is an interface')
+    ->expect('pxlrbt\LaravelPdfable\Drivers\Driver')
+    ->toBeInterface();
+
+arch('drivers implement the Driver interface')
+    ->expect('pxlrbt\LaravelPdfable\Drivers\BrowsershotDriver')
+    ->toImplement('pxlrbt\LaravelPdfable\Drivers\Driver');

--- a/tests/Commands/MakeCommandTest.php
+++ b/tests/Commands/MakeCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    File::deleteDirectory(app_path('Pdfs'));
+    File::deleteDirectory(resource_path('views/pdfs'));
+});
+
+afterEach(function () {
+    File::deleteDirectory(app_path('Pdfs'));
+    File::deleteDirectory(resource_path('views/pdfs'));
+});
+
+it('creates a pdfable class and view', function () {
+    $this->artisan('make:pdf', ['name' => 'Invoice'])
+        ->assertSuccessful();
+
+    expect(File::exists(app_path('Pdfs/Invoice.php')))->toBeTrue()
+        ->and(File::exists(resource_path('views/pdfs/invoice.blade.php')))->toBeTrue();
+});
+
+it('generates correct class content', function () {
+    $this->artisan('make:pdf', ['name' => 'Invoice']);
+
+    $content = File::get(app_path('Pdfs/Invoice.php'));
+
+    expect($content)->toContain('namespace App\Pdfs')
+        ->and($content)->toContain('class Invoice extends Pdfable')
+        ->and($content)->toContain("public string \$view = 'invoice'");
+});
+
+it('generates correct view content', function () {
+    $this->artisan('make:pdf', ['name' => 'Invoice']);
+
+    $content = File::get(resource_path('views/pdfs/invoice.blade.php'));
+
+    expect($content)->toContain("@extends('laravel-pdfable::base')")
+        ->and($content)->toContain("@section('content')");
+});
+
+it('converts name to studly case for class', function () {
+    $this->artisan('make:pdf', ['name' => 'monthly-report']);
+
+    expect(File::exists(app_path('Pdfs/MonthlyReport.php')))->toBeTrue();
+
+    $content = File::get(app_path('Pdfs/MonthlyReport.php'));
+
+    expect($content)->toContain('class MonthlyReport extends Pdfable');
+});
+
+it('rejects invalid class names', function () {
+    $this->artisan('make:pdf', ['name' => '123invalid'])
+        ->assertSuccessful();
+
+    expect(File::exists(app_path('Pdfs/123invalid.php')))->toBeFalse();
+});
+
+it('rejects reserved class names', function () {
+    $this->artisan('make:pdf', ['name' => 'class'])
+        ->assertSuccessful();
+
+    expect(File::exists(app_path('Pdfs/Class.php')))->toBeFalse();
+});
+
+it('does not overwrite existing files without force', function () {
+    $this->artisan('make:pdf', ['name' => 'Invoice']);
+
+    File::put(app_path('Pdfs/Invoice.php'), 'original content');
+
+    $this->artisan('make:pdf', ['name' => 'Invoice']);
+
+    expect(File::get(app_path('Pdfs/Invoice.php')))->toBe('original content');
+});
+
+it('overwrites existing files with force flag', function () {
+    $this->artisan('make:pdf', ['name' => 'Invoice']);
+
+    File::put(app_path('Pdfs/Invoice.php'), 'original content');
+
+    $this->artisan('make:pdf', ['name' => 'Invoice', '--force' => true]);
+
+    expect(File::get(app_path('Pdfs/Invoice.php')))->not->toBe('original content')
+        ->and(File::get(app_path('Pdfs/Invoice.php')))->toContain('class Invoice extends Pdfable');
+});

--- a/tests/Concerns/CanAccessPropertiesAndMethodsTest.php
+++ b/tests/Concerns/CanAccessPropertiesAndMethodsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use pxlrbt\LaravelPdfable\Pdfable;
+
+beforeEach(function () {
+    // Clear static caches between tests
+    $reflection = new ReflectionClass(Pdfable::class);
+
+    $propertyCache = $reflection->getProperty('propertyCache');
+    $propertyCache->setValue(null, []);
+
+    $methodCache = $reflection->getProperty('methodCache');
+    $methodCache->setValue(null, []);
+});
+
+it('exposes public properties via data()', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'test-view';
+
+        public string $title = 'My Title';
+    };
+
+    $data = $pdf->data();
+
+    expect($data)->toHaveKey('title', 'My Title');
+});
+
+it('excludes static properties from data()', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'test-view';
+
+        public static string $staticProp = 'hidden';
+    };
+
+    $data = $pdf->data();
+
+    expect($data)->not->toHaveKey('staticProp');
+});
+
+it('exposes public methods as invokable variables', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'test-view';
+
+        public function greeting(): string
+        {
+            return 'Hello World';
+        }
+    };
+
+    $data = $pdf->data();
+
+    expect($data)->toHaveKey('greeting')
+        ->and((string) $data['greeting'])->toBe('Hello World');
+});
+
+it('exposes methods with parameters as closures', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'test-view';
+
+        public function greet(string $name): string
+        {
+            return "Hello {$name}";
+        }
+    };
+
+    $data = $pdf->data();
+
+    expect($data)->toHaveKey('greet')
+        ->and($data['greet'])->toBeInstanceOf(Closure::class)
+        ->and($data['greet']('World'))->toBe('Hello World');
+});
+
+it('ignores magic methods', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'test-view';
+    };
+
+    $data = $pdf->data();
+
+    expect($data)->not->toHaveKey('__construct');
+});
+
+it('ignores methods listed in ignoredMethods', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'test-view';
+    };
+
+    $data = $pdf->data();
+
+    expect($data)->not->toHaveKey('data')
+        ->and($data)->not->toHaveKey('render')
+        ->and($data)->not->toHaveKey('shouldRender');
+});
+
+it('respects except property', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'test-view';
+
+        protected $except = ['customMethod'];
+
+        public function customMethod(): string
+        {
+            return 'hidden';
+        }
+    };
+
+    $data = $pdf->data();
+
+    expect($data)->not->toHaveKey('customMethod');
+});
+
+it('includes attributes in data', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'test-view';
+    };
+
+    $data = $pdf->data();
+
+    expect($data)->toHaveKey('attributes');
+});

--- a/tests/Concerns/CanBeAttachedTest.php
+++ b/tests/Concerns/CanBeAttachedTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Mail\Attachment;
+use pxlrbt\LaravelPdfable\Pdfable;
+
+it('creates a mail attachment', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+
+        public function filename(): string
+        {
+            return 'invoice.pdf';
+        }
+    };
+
+    $attachment = $pdf->toMailAttachment();
+
+    expect($attachment)->toBeInstanceOf(Attachment::class);
+});

--- a/tests/Concerns/CanBeQueuedTest.php
+++ b/tests/Concerns/CanBeQueuedTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\Storage;
+use pxlrbt\LaravelPdfable\Drivers\Driver;
+use pxlrbt\LaravelPdfable\Pdfable;
+
+it('saves pdf when handled as a job', function () {
+    Storage::fake('local');
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('getData')->once()->andReturn('pdf-content');
+
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+
+        public function filename(): string
+        {
+            return 'queued.pdf';
+        }
+    };
+
+    app()->instance(get_class($driver), $driver);
+    config(['pdfable.drivers.browsershot' => get_class($driver)]);
+
+    $pdf->handle();
+
+    Storage::disk('local')->assertExists('queued.pdf');
+});

--- a/tests/Concerns/CanBeRenderedTest.php
+++ b/tests/Concerns/CanBeRenderedTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use pxlrbt\LaravelPdfable\Pdfable;
+
+it('sets preview to true when rendering', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    expect($pdf->preview)->toBeFalse();
+
+    $pdf->render();
+
+    expect($pdf->preview)->toBeTrue();
+});
+
+it('returns display filename from full path', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+
+        public function filename(): string
+        {
+            return 'invoices/2024/invoice-123.pdf';
+        }
+    };
+
+    expect($pdf->displayFilename())->toBe('invoice-123.pdf');
+});
+
+it('returns default filename when not overridden', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    expect($pdf->displayFilename())->toBe('default.pdf');
+});

--- a/tests/Concerns/CanBeStoredTest.php
+++ b/tests/Concerns/CanBeStoredTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Illuminate\Support\Facades\Storage;
+use pxlrbt\LaravelPdfable\Drivers\Driver;
+use pxlrbt\LaravelPdfable\Pdfable;
+
+it('returns default filename', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    expect($pdf->filename())->toBe('default.pdf');
+});
+
+it('allows overriding filename', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+
+        public function filename(): string
+        {
+            return 'custom.pdf';
+        }
+    };
+
+    expect($pdf->filename())->toBe('custom.pdf');
+});
+
+it('sets disk via fluent method', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    $result = $pdf->disk('s3');
+
+    expect($result)->toBeInstanceOf(Pdfable::class);
+});
+
+it('saves pdf to storage', function () {
+    Storage::fake('local');
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('getData')->once()->andReturn('pdf-content');
+
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+
+        public function filename(): string
+        {
+            return 'test.pdf';
+        }
+    };
+
+    app()->instance(get_class($driver), $driver);
+    config(['pdfable.drivers.browsershot' => get_class($driver)]);
+
+    $result = $pdf->save();
+
+    expect($result)->toBeInstanceOf(Pdfable::class);
+    Storage::disk('local')->assertExists('test.pdf');
+});
+
+it('saves pdf with custom filename', function () {
+    Storage::fake('local');
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('getData')->once()->andReturn('pdf-content');
+
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    app()->instance(get_class($driver), $driver);
+    config(['pdfable.drivers.browsershot' => get_class($driver)]);
+
+    $pdf->save('custom-name.pdf');
+
+    Storage::disk('local')->assertExists('custom-name.pdf');
+});
+
+it('saves pdf to specific disk', function () {
+    Storage::fake('s3');
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('getData')->once()->andReturn('pdf-content');
+
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    app()->instance(get_class($driver), $driver);
+    config(['pdfable.drivers.browsershot' => get_class($driver)]);
+
+    $pdf->disk('s3')->save('test.pdf');
+
+    Storage::disk('s3')->assertExists('test.pdf');
+});

--- a/tests/Drivers/BrowsershotDriverTest.php
+++ b/tests/Drivers/BrowsershotDriverTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use pxlrbt\LaravelPdfable\Drivers\BrowsershotDriver;
+use pxlrbt\LaravelPdfable\Drivers\Driver;
+
+it('implements the Driver interface', function () {
+    expect(BrowsershotDriver::class)->toImplement(Driver::class);
+});
+
+it('accepts a configuration callback', function () {
+    $called = false;
+
+    BrowsershotDriver::configureUsing(function ($browser) use (&$called) {
+        $called = true;
+
+        return $browser;
+    });
+
+    // Reset static state
+    $reflection = new ReflectionClass(BrowsershotDriver::class);
+    $property = $reflection->getProperty('configureUsing');
+    $value = $property->getValue(null);
+
+    expect($value)->toBeInstanceOf(Closure::class);
+
+    // Clean up
+    $property->setValue(null, null);
+});

--- a/tests/Drivers/WkhtmltopdfDriverTest.php
+++ b/tests/Drivers/WkhtmltopdfDriverTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use pxlrbt\LaravelPdfable\Drivers\Driver;
+use pxlrbt\LaravelPdfable\Drivers\WkhtmltopdfDriver;
+
+it('implements the Driver interface', function () {
+    expect(WkhtmltopdfDriver::class)->toImplement(Driver::class);
+});

--- a/tests/Layout/PageSizeTest.php
+++ b/tests/Layout/PageSizeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use pxlrbt\LaravelPdfable\Layout\PageSize;
+
+it('returns correct dimensions for A4', function () {
+    expect(PageSize::A4->size())->toBe([210, 297]);
+});
+
+it('returns correct dimensions for A3', function () {
+    expect(PageSize::A3->size())->toBe([297, 420]);
+});
+
+it('returns correct dimensions for A5', function () {
+    expect(PageSize::A5->size())->toBe([148, 210]);
+});
+
+it('returns correct dimensions for Letter', function () {
+    expect(PageSize::Letter->size())->toBe([216, 279]);
+});
+
+it('returns correct dimensions for Legal', function () {
+    expect(PageSize::Legal->size())->toBe([216, 356]);
+});
+
+it('returns correct dimensions for Tabloid', function () {
+    expect(PageSize::Tabloid->size())->toBe([279, 432]);
+});

--- a/tests/Layout/PageTest.php
+++ b/tests/Layout/PageTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use pxlrbt\LaravelPdfable\Layout\Page;
+use pxlrbt\LaravelPdfable\Layout\PageOrientation;
+use pxlrbt\LaravelPdfable\Layout\PageSize;
+
+it('creates page with default config values', function () {
+    $page = Page::make();
+
+    expect($page->getWidth())->toBe(210)
+        ->and($page->getHeight())->toBe(297)
+        ->and($page->getMargins())->toBe([25.4, 19.05, 25.4, 19.05]);
+});
+
+it('sets size from PageSize enum', function () {
+    $page = Page::make()->size(PageSize::A3);
+
+    expect($page->getWidth())->toBe(297)
+        ->and($page->getHeight())->toBe(420);
+});
+
+it('sets size from custom array', function () {
+    $page = Page::make()->size([100, 200]);
+
+    expect($page->getWidth())->toBe(100)
+        ->and($page->getHeight())->toBe(200);
+});
+
+it('sets orientation to landscape', function () {
+    $page = Page::make()->landscape();
+
+    expect($page->getWidth())->toBe(297)
+        ->and($page->getHeight())->toBe(210);
+});
+
+it('sets orientation to portrait', function () {
+    $page = Page::make()->landscape()->portrait();
+
+    expect($page->getWidth())->toBe(210)
+        ->and($page->getHeight())->toBe(297);
+});
+
+it('sets orientation via enum', function () {
+    $page = Page::make()->orientation(PageOrientation::Landscape);
+
+    expect($page->getWidth())->toBe(297)
+        ->and($page->getHeight())->toBe(210);
+});
+
+it('swaps width and height in landscape mode', function () {
+    $page = Page::make()->size(PageSize::A5)->landscape();
+
+    expect($page->getWidth())->toBe(210)
+        ->and($page->getHeight())->toBe(148);
+});
+
+it('sets margins from named preset string', function () {
+    $page = Page::make()->margins('narrow');
+
+    expect($page->getMargins())->toBe([12.7, 12.7, 12.7, 12.7]);
+});
+
+it('sets margins from custom array', function () {
+    $page = Page::make()->margins([10, 20, 30, 40]);
+
+    expect($page->getMargins())->toBe([10, 20, 30, 40]);
+});
+
+it('returns individual margins', function () {
+    $page = Page::make()->margins([10, 20, 30, 40]);
+
+    expect($page->getMarginTop())->toBe(10)
+        ->and($page->getMarginRight())->toBe(20)
+        ->and($page->getMarginBottom())->toBe(30)
+        ->and($page->getMarginLeft())->toBe(40);
+});
+
+it('supports none margins preset', function () {
+    $page = Page::make()->margins('none');
+
+    expect($page->getMargins())->toBe([0, 0, 0, 0]);
+});
+
+it('supports wide margins preset', function () {
+    $page = Page::make()->margins('wide');
+
+    expect($page->getMargins())->toBe([25.4, 50.8, 25.4, 50.8]);
+});
+
+it('returns fluent interface from all setters', function () {
+    $page = Page::make();
+
+    expect($page->size(PageSize::A4))->toBeInstanceOf(Page::class)
+        ->and($page->orientation(PageOrientation::Portrait))->toBeInstanceOf(Page::class)
+        ->and($page->portrait())->toBeInstanceOf(Page::class)
+        ->and($page->landscape())->toBeInstanceOf(Page::class)
+        ->and($page->margins('narrow'))->toBeInstanceOf(Page::class);
+});

--- a/tests/PdfableTest.php
+++ b/tests/PdfableTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Contracts\Mail\Attachable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Contracts\View\View;
+use pxlrbt\LaravelPdfable\Drivers\Driver;
+use pxlrbt\LaravelPdfable\Layout\Page;
+use pxlrbt\LaravelPdfable\Pdfable;
+
+it('implements required interfaces', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    expect($pdf)->toBeInstanceOf(Attachable::class)
+        ->and($pdf)->toBeInstanceOf(Renderable::class)
+        ->and($pdf)->toBeInstanceOf(ShouldQueue::class);
+});
+
+it('resolves the configured driver', function () {
+    $driver = Mockery::mock(Driver::class);
+    app()->instance(get_class($driver), $driver);
+    config(['pdfable.drivers.browsershot' => get_class($driver)]);
+
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    expect($pdf->driver())->toBeInstanceOf(Driver::class);
+});
+
+it('returns a Page instance from page()', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    expect($pdf->page())->toBeInstanceOf(Page::class);
+});
+
+it('has preview disabled by default', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    expect($pdf->preview)->toBeFalse();
+});
+
+it('returns a view from getView()', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+    };
+
+    $view = $pdf->getView();
+
+    expect($view)->toBeInstanceOf(View::class);
+});
+
+it('passes data to the view', function () {
+    $pdf = new class extends Pdfable
+    {
+        public string $view = 'laravel-pdfable::base';
+
+        public string $title = 'Test PDF';
+    };
+
+    $view = $pdf->getView();
+    $data = $view->getData();
+
+    expect($data)->toHaveKey('title', 'Test PDF');
+});


### PR DESCRIPTION
## Summary

- 61 Pest tests covering all package functionality
- Tests organized by domain: Layout, Concerns, Drivers, Commands, and architecture
- Covers Page/PageSize/PageOrientation, all 5 concern traits, MakeCommand, driver interfaces, and Pdfable core

## Test plan

- [x] All 61 tests passing locally
- [x] Code formatted with Pint
- [ ] CI pipeline passes